### PR TITLE
Added header to Install target

### DIFF
--- a/cmake/CMakeUnix.cmake
+++ b/cmake/CMakeUnix.cmake
@@ -28,6 +28,10 @@ INSTALL(CODE "
   )
 ")
 
+## Install Headers in APACHE_INCLUDE_DIR
+INSTALL(FILES websocket_plugin.h DESTINATION ${APACHE_INCLUDE_DIR})
+# INSTALL(FILES validate_utf8.h DESTINATION ${APACHE_INCLUDE_DIR})
+
 ### Build Examples
 IF (BUILD_EXAMPLES)
   SET(example_targets


### PR DESCRIPTION
"websocket_plugin" is copied in APACHE_INCLUDE_DIR in order to be able to develop other plugin without using this repository.
